### PR TITLE
Hide "Request timed out." message when calling quiet_ping()

### DIFF
--- a/ping.py
+++ b/ping.py
@@ -375,7 +375,8 @@ def do_one(myStats, destIP, hostname, timeout, mySeqNumber, numDataBytes, quiet 
             myStats.maxTime = delay
     else:
         delay = None
-        print("Request timed out.")
+        if not quiet:
+            print("Request timed out.")
 
     return delay
 


### PR DESCRIPTION
Hide "Request timed out." message when calling quiet_ping()