### PR TITLE
Updated LICENSE to full GPLv2.

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -16,6 +16,9 @@ You should have received a copy of the GNU General Public License
 along with this program; if not, write to the Free Software
 Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
+To report a change or a bug, open an issue on
+https://github.com/l4m3rx/python-ping or email one of the contributors.
+
 -------------------------------------------------------------------------------
 PREVIOUS LICENSING STATEMENT.
 

--- a/LICENSE
+++ b/LICENSE
@@ -1,3 +1,24 @@
+A pure python implementation of netkit's ping.c
+
+Copyright (C) 2016, python-ping team
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+
+-------------------------------------------------------------------------------
+PREVIOUS LICENSING STATEMENT.
+
 The original code derived from ping.c distributed in Linux's netkit.
 That code is copyright (c) 1989 by The Regents of the University of California.
 That code is in turn derived from code written by Mike Muuss of the


### PR DESCRIPTION
Closes #24 on https://github.com/l4m3rx/python-ping

The old license is left intact because I am unsure if the cited author is still
involved in the project.

I am also unsure as to whether or not the copyright should be left to 2016 or
date back to the project origin.